### PR TITLE
fix(docker): simplify build process and improve security

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -1,6 +1,14 @@
 name: CI Workflow
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,24 +25,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 # Final stage
 FROM python:3.10-slim-trixie
 
-# Install minimal audio processing - only ffmpeg runtime libraries
-COPY --from=jrottenberg/ffmpeg:latest /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
     wget
-
-# Install yt-dlp (single binary, no Python dependency)
-RUN wget -O /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
-    && chmod +x /usr/local/bin/yt-dlp \
-    && apt-get purge -y --auto-remove wget \
-    && rm -rf /var/lib/apt/lists/*
 
 # Copy binary
 COPY --from=build /parrot/target/release/parrot /usr/local/bin/
 COPY --chmod=0755 ./entrypoint.sh .
-
-# Create non-root user
-RUN useradd -m -u 1000 parrot
-USER parrot
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,48 @@
-# Build image
+# Build stage
 FROM rust:1.93-slim AS build
-
-# Install build dependencies and clean up in the same layer
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    build-essential autoconf automake cmake libtool libssl-dev pkg-config
 
 WORKDIR /parrot
 
-# Cache cargo dependencies by copying only Cargo files and creating dummy source
-COPY Cargo.toml Cargo.lock ./
-
-# Create dummy source files to satisfy Cargo (supports both binary and library crates)
-RUN mkdir -p src && \
-    echo "fn main() {}" > src/main.rs
-
-# Build dependencies - this layer will be cached as long as Cargo.toml/Cargo.lock don't change
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --locked
-
-# Copy only source files needed for compilation (exclude entrypoint.sh and other non-build files)
-COPY src/ ./src/
-
-# Build the actual application
-RUN --mount=type=cache,target=/usr/local/cargo/registry \
-    cargo build --release --locked
-
-# Release image
-FROM debian:trixie-slim
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg wget \
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    pkg-config \
+    libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src && echo "fn main() {}" > src/main.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --locked
+
+# Copy source and build
+COPY src/ ./src/
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    cargo build --release --locked
+
+# Final stage
+FROM python:3.10-slim-trixie
+
+# Install minimal audio processing - only ffmpeg runtime libraries
+COPY --from=jrottenberg/ffmpeg:latest /usr/local/bin/ffmpeg /usr/local/bin/ffmpeg
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget
+
+# Install yt-dlp (single binary, no Python dependency)
+RUN wget -O /usr/local/bin/yt-dlp https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp \
+    && chmod +x /usr/local/bin/yt-dlp \
+    && apt-get purge -y --auto-remove wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy binary
 COPY --from=build /parrot/target/release/parrot /usr/local/bin/
 COPY --chmod=0755 ./entrypoint.sh .
+
+# Create non-root user
+RUN useradd -m -u 1000 parrot
+USER parrot
 
 ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O /usr/local/bin/yt-dlp
+chmod a+rx /usr/local/bin/yt-dlp
 yt-dlp -U
 
 parrot

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,28 +1,4 @@
 #!/bin/sh
-
-ARCH=$(uname -m)
-
-# Convert aarch64 to arm64 and x86_64 to amd64 for consistency
-if [ "$ARCH" = "aarch64" ]; then
-    ARCH="arm64"
-elif [ "$ARCH" = "x86_64" ]; then
-    ARCH="amd64"
-fi
-
-echo "Running on architecture: $ARCH"
-
-
-if [ "$ARCH" = "arm64" ]; then
-    # Commands specific to ARM
-    YTDLP_LINK=https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux_aarch64
-elif [ "$ARCH" = "amd64" ]; then
-    # Commands specific to x86/AMD64
-    YTDLP_LINK=https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux
-fi
-
-
-wget --no-check-certificate $YTDLP_LINK -O /usr/local/bin/yt-dlp
-
-chmod a+rx /usr/local/bin/yt-dlp
+yt-dlp -U
 
 parrot


### PR DESCRIPTION
- consolidate docker build stages for better caching
- remove redundant dependency installations
- update entrypoint to run `yt-dlp -U`
- limit ci workflow to main/master branches
- ignore markdown and docs changes in pull requests
- add ready_for_review event trigger for pull requests